### PR TITLE
Switch to Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .idea
 *venv*
+.psychopy_py310
+data
+build
+__pycache__
+.demos

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "psychopy-projects"]
+[submodule "psychopy-projects/"]
 	path = psychopy-projects
-	url = git@github.com:Brain-Music-Lab/psychopy-projects.git
+	url = https://github.com/Brain-Music-Lab/psychopy-projects.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,0 @@
-[submodule "psychopy-projects/"]
-	path = psychopy-projects
-	url = git@github.com:Brain-Music-Lab/psychopy-projects.git
-[submodule "psychopy-projects/"]
-	url = https://github.com/Brain-Music-Lab/psychopy-projects.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "psychopy-projects"]
+	path = psychopy-projects
+	url = git@github.com:Brain-Music-Lab/psychopy-projects.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "psychopy-projects"]
 	path = psychopy-projects
 	url = git@github.com:Brain-Music-Lab/psychopy-projects.git
+[submodule "psychopy-projects/"]
+	url = https://github.com/Brain-Music-Lab/psychopy-projects.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "psychopy-projects"]
+	path = psychopy-projects
+	url = https://github.com/Brain-Music-Lab/psychopy-projects.git

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# ListenerFacingDesign
+# Brain Music Lab Data Station
+The Brain Music Lab (BML) Data station is a physical installation capable of running different psychopy studies all from the same interface. (Check out the [development of the hardware](https://sophiamontie.com/brain-music-lab-instillation).)
+
+
+# Getting Started
+## Cloning
+This repository uses submodules. To clone, run: 
+- (HTTPS) `git clone https://github.com/Brain-Music-Lab/ListenerFacingDesign.git --recuse-submodules`
+- (SSH) `git clone git@github.com:Brain-Music-Lab/ListenerFacingDesign.git --recuse-submodules`
+
+If the repository is already cloned, run `git submodule update --init --recursive`
+
+## Getting the Right Python Version
+The software requires Python 3.10. Run `python --version` to check. If your default Python version is not 3.10, you will need to switch to that. Some ideas to try are below:
+
+1. `cd ListenerFacingDesign && python3.10 -m venv .venv`
+    - If this works, this will create a python virtual environment using python 3.10. 
+    - Confirm this worked by running `python --version`. The output should be "Python 3.10.X"
+2. If idea 1. doesn't work, we recommend using [pyenv](https://realpython.com/intro-to-pyenv/) to acquire Python 3.10 without messing up the current Python environment.
+
+## Setting up the Development Environment
+If step 1. above worked for you, you have a virtual environment skip to step 2. 
+
+1) `cd ListenerFacingDesign && python -m venv .venv`
+2) `pip install --upgrade pip`
+3) `pip install requirements.txt`
+
+## Running the Software Locally
+- `cd ListenerFacingDesign`
+- `python src/main.py`
+
+## Adding a Psychopy Project
+All psychopy projects are kept in the `psychopy-projects` submodule. See the top-level `README.md` for details on adding another project.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy==2.2.3
+psychopy==2024.2.5
+PyQt6==6.8.1
+PyQt6_sip==13.10.0

--- a/src/consent.py
+++ b/src/consent.py
@@ -1,0 +1,30 @@
+from PyQt6.QtWidgets import QMainWindow, QPushButton, QWidget, QVBoxLayout
+from PyQt6.QtCore import pyqtSignal
+
+
+class ConsentWindow(QMainWindow):
+    closed = pyqtSignal()  # Add close signal
+    
+    def __init__(self, parent):
+        super().__init__()
+        self.main_window: QMainWindow = parent
+        self.setWindowTitle("Consent Form")
+        self.setGeometry(200, 200, 400, 200)
+        
+        # Create central widget and layout
+        central_widget = QWidget()
+        self.setCentralWidget(central_widget)
+        layout = QVBoxLayout(central_widget)
+        
+        # Add accept button
+        self.accept_button = QPushButton("Accept")
+        self.accept_button.clicked.connect(self.on_accept)
+        layout.addWidget(self.accept_button)
+    
+    def on_accept(self):
+        self.main_window.open_dashboard()
+        self.close()
+
+    def closeEvent(self, event):
+        self.closed.emit()
+        super().closeEvent(event)

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -1,0 +1,63 @@
+from PyQt6.QtWidgets import (QMainWindow, QWidget, QVBoxLayout, QLabel, 
+                           QPushButton, QGridLayout)
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtGui import QCloseEvent
+import os
+
+class Dashboard(QMainWindow):
+    closed = pyqtSignal()  # Add close signal
+    
+    def format_folder_name(self, name):
+        """Convert folder names like 'my-folder-name' to 'My Folder Name'"""
+        return ' '.join(word.capitalize() for word in name.split('-'))
+    
+    def __init__(self, parent):
+        super().__init__()
+        self.main_window = parent
+        self.setWindowTitle("Dashboard")
+        self.setGeometry(200, 200, 800, 600)
+        
+        # Create central widget and main layout
+        central_widget = QWidget()
+        self.setCentralWidget(central_widget)
+        main_layout = QVBoxLayout(central_widget)
+        
+        # Add return to consent button at the top
+        self.consent_button = QPushButton("Back to consent form")
+        self.consent_button.clicked.connect(self.on_return_to_dashboard)
+        main_layout.addWidget(self.consent_button)
+        
+        # Create grid layout for project buttons
+        grid_layout = QGridLayout()
+        main_layout.addLayout(grid_layout)
+        
+        # Add all project folder buttons in a grid
+        projects_path = "psychopy-projects"
+        if os.path.exists(projects_path):
+            folders = [f for f in os.listdir(projects_path) 
+                      if os.path.isdir(os.path.join(projects_path, f))]
+            
+            # Calculate grid dimensions (3 buttons per row)
+            buttons_per_row = 3
+            
+            for i, folder in enumerate(folders):
+                display_name = self.format_folder_name(folder)
+                button = QPushButton(display_name)
+                button.setMinimumSize(200, 100)  # Make buttons bigger
+                button.clicked.connect(lambda checked, name=folder: 
+                    print(f"Selected project: {self.format_folder_name(name)}"))
+                row = i // buttons_per_row
+                col = i % buttons_per_row
+                grid_layout.addWidget(button, row, col)
+        else:
+            placeholder = QLabel("No projects found in psychopy-projects directory")
+            placeholder.setStyleSheet("font-size: 24px; color: gray;")
+            main_layout.addWidget(placeholder)
+
+    def on_return_to_dashboard(self):
+        self.main_window.open_consent()
+        self.close()
+    
+    def closeEvent(self, event: QCloseEvent):
+        self.closed.emit()
+        super().closeEvent(event)

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,70 @@
+from PyQt6.QtWidgets import QApplication, QMainWindow, QPushButton
+from PyQt6.QtGui import QCloseEvent
+from consent import ConsentWindow
+from dashboard import Dashboard
+import sys
+
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Brain Music Lab - Data Station")
+        self.setGeometry(100, 100, 400, 200)
+        
+        # Create and center the button
+        self.consent_button = QPushButton("Run", self)
+        button_width = 200
+        button_height = 40
+        x = (self.width() - button_width) // 2
+        y = (self.height() - button_height) // 2
+        self.consent_button.setGeometry(x, y, button_width, button_height)
+        self.consent_button.clicked.connect(self.open_consent)
+        self.consent_window = None
+        self.dashboard = None
+    
+    def open_consent(self):
+        if not self.consent_window or not self.consent_window.isVisible():
+            self.consent_window = ConsentWindow(self)
+            self.consent_window.closed.connect(self.on_consent_closed)
+            self.consent_button.setText("Running")
+            self.consent_window.show()
+
+    def open_dashboard(self):
+        if not self.dashboard or not self.dashboard.isVisible():
+            self.dashboard = Dashboard(self)
+            self.dashboard.closed.connect(self.on_dashboard_closed)
+            self.consent_button.setText("Running")
+            self.dashboard.show()
+
+    def on_consent_closed(self):
+        self.consent_window.destroy()
+        self.consent_window = None
+
+        if not self.dashboard:
+            self.consent_button.setText("Run")
+
+    def on_dashboard_closed(self):
+        self.dashboard.destroy()
+        self.dashboard = None
+
+        if not self.consent_window:
+            self.consent_button.setText("Run")
+
+    def closeEvent(self, event: QCloseEvent):
+        if self.dashboard:
+            self.dashboard.close()
+
+        if self.consent_window:
+            self.consent_window.close()
+        
+        super().closeEvent(event)
+
+
+
+def main():
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec())
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
# Overview
Instead of using C++, we can use solely Python for this project. 

# Instructions
Follow the instructions in the README file on the add-psychopy-submodule branch. Note any difficulties or places for more detail in comments.

# Once built, ensure that the buttons work
- The button about the test project currently only prints to the console. 
- The other buttons go to other screens.